### PR TITLE
feat(frontend): add enterprise header and footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,5 @@ Thumbs.db
 logs/
 temp/
 tmp/
+# Node.js dependencies
+**/node_modules/

--- a/frontend/app/components/Footer.tsx
+++ b/frontend/app/components/Footer.tsx
@@ -1,0 +1,9 @@
+export default function Footer() {
+  return (
+    <footer className="bg-white border-t mt-12">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 text-center text-sm text-gray-500">
+        © {new Date().getFullYear()} Prompt Ops Hub. All rights reserved.
+      </div>
+    </footer>
+  );
+}

--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+
+export default function Header() {
+  return (
+    <header className="bg-white border-b shadow-sm">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+        <Link href="/" className="text-xl font-semibold text-gray-900">
+          Prompt Ops Hub
+        </Link>
+        <nav className="flex items-center space-x-4">
+          <Link
+            href="/runs"
+            className="text-gray-600 hover:text-gray-900 px-3 py-2 rounded-md text-sm font-medium"
+          >
+            Runs
+          </Link>
+          <Link
+            href="/integrity"
+            className="text-gray-600 hover:text-gray-900 px-3 py-2 rounded-md text-sm font-medium"
+          >
+            Integrity
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -6,6 +6,9 @@
   html {
     font-family: system-ui, sans-serif;
   }
+  body {
+    @apply bg-gray-50 text-gray-900;
+  }
 }
 
 @layer components {
@@ -22,6 +25,6 @@
   }
   
   .card {
-    @apply bg-white shadow rounded-lg p-6;
+    @apply bg-white border border-gray-200 rounded-lg shadow-sm p-6;
   }
-} 
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,9 +1,10 @@
 import './globals.css';
 import { Inter } from 'next/font/google';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import Header from './components/Header';
+import Footer from './components/Footer';
 
 const inter = Inter({ subsets: ['latin'] });
-
 const queryClient = new QueryClient();
 
 export const metadata = {
@@ -20,38 +21,15 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <QueryClientProvider client={queryClient}>
-          <div className="min-h-screen bg-gray-50">
-            <nav className="bg-white shadow-sm border-b">
-              <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                <div className="flex justify-between h-16">
-                  <div className="flex items-center">
-                    <h1 className="text-xl font-semibold text-gray-900">
-                      Prompt Ops Hub
-                    </h1>
-                  </div>
-                  <div className="flex items-center space-x-4">
-                    <a
-                      href="/runs"
-                      className="text-gray-500 hover:text-gray-700 px-3 py-2 rounded-md text-sm font-medium"
-                    >
-                      Runs
-                    </a>
-                    <a
-                      href="/integrity"
-                      className="text-gray-500 hover:text-gray-700 px-3 py-2 rounded-md text-sm font-medium"
-                    >
-                      Integrity
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </nav>
-            <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+          <div className="min-h-screen flex flex-col bg-gray-50">
+            <Header />
+            <main className="flex-1 w-full max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
               {children}
             </main>
+            <Footer />
           </div>
         </QueryClientProvider>
       </body>
     </html>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- add reusable header and footer components for a consistent enterprise-style layout
- centralize layout with flex column to ensure footer positioning
- refine global styles with background, text color, and card borders

## Testing
- `pip install -e .[dev]` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `pytest` *(fails: unrecognized arguments: --cov=src --cov-report=term-missing --cov-report=xml)*
- `python -m integrity_core.coverage`
- `python -m integrity_core.diff_coverage`
- `python -m integrity_core.tamper`
- `python -m integrity_core.policy`
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b4da5560e8832a89aebcf91d3e4fc6