### PR TITLE
refactor: use specific exception handling and logging

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -4,6 +4,8 @@
 import typer
 import os
 from pathlib import Path
+import logging
+from sqlalchemy.exc import SQLAlchemyError
 
 from src.core.db import get_db_manager
 from src.core.guardrails import guardrails
@@ -18,6 +20,8 @@ from src.cli_init.project_scaffold import ProjectScaffold
 from src.cli_snippet.ci_snippet import CISnippetGenerator
 
 app = typer.Typer(help="Prompt Ops Hub CLI")
+
+logger = logging.getLogger(__name__)
 
 
 @app.command()
@@ -51,7 +55,8 @@ def task(
             typer.echo(f"\nTask saved with ID: {task.id}")
             typer.echo(f"Created at: {task.created_at}")
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -92,7 +97,8 @@ def list(
 
             typer.echo("-" * 40)
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"❌ Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -123,7 +129,8 @@ def show(
         typer.echo(task.built_prompt)
         typer.echo("=" * 80)
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"❌ Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -147,7 +154,8 @@ def delete(
             typer.echo(f"❌ Task {task_id} not found.")
             raise typer.Exit(1)
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"❌ Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -159,7 +167,8 @@ def init():
         db_manager = get_db_manager()
         db_manager.create_tables()
         typer.echo("Database initialized successfully")
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -233,12 +242,14 @@ def run_task(
                 typer.echo(f"❌ Tests failed: {test_result.error_message}")
                 raise typer.Exit(1)
 
-        except Exception as e:
+        except (ValueError, RuntimeError, SQLAlchemyError) as e:
+            logger.exception("Unhandled error")
             db_manager.update_run_status(run.id, "error", f"Execution error: {str(e)}")
             typer.echo(f"❌ Execution error: {str(e)}")
             raise typer.Exit(1)
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"❌ Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -330,7 +341,8 @@ def pr(
             typer.echo(f"❌ Failed to create PR: {pr_result.error_message}")
             raise typer.Exit(1)
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"❌ Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -369,7 +381,8 @@ def runs(
 
             typer.echo("-" * 40)
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"❌ Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -411,7 +424,8 @@ def expand(
 
         typer.echo("=" * 80)
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"❌ Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -447,7 +461,8 @@ def run_auto(
                 typer.echo(f"  - Final error: {result.escalation_payload.get('final_error', 'Unknown')}")
                 typer.echo(f"  - Recommended action: {result.escalation_payload.get('recommended_action', 'Unknown')}")
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"❌ Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -483,7 +498,8 @@ def clarify(
             typer.echo(f"Error: {result.error_message}")
             raise typer.Exit(1)
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -529,7 +545,8 @@ def policy_check(
         if not result.allowed:
             raise typer.Exit(1)
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"❌ Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -576,7 +593,8 @@ def integrity(
 
         typer.echo("=" * 80)
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"❌ Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -616,7 +634,8 @@ def answer(
         # Store answers (in a real implementation, this would update the run)
         typer.echo("answered")
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -657,7 +676,8 @@ def init_project(
                 typer.echo(f"  - {error}")
             raise typer.Exit(1)
     
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -708,7 +728,8 @@ def ci_snippet(
             typer.echo(f"   Integrity gates: {len(summary['integrity_gates'])}")
             typer.echo(f"   Hash: {summary['hash']}")
     
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,8 @@ import os
 import json
 
 from fastapi import FastAPI, HTTPException, Form, Query, Body
+import logging
+from sqlalchemy.exc import SQLAlchemyError
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -13,6 +15,8 @@ from src.core.models import RunCreate, RunResponse, TaskCreate, TaskResponse
 from src.core.prompt_builder import prompt_builder
 from src.services.cursor_adapter import cursor_adapter
 from src.services.github_adapter import get_github_adapter
+
+logger = logging.getLogger(__name__)
 
 # Pydantic models for request bodies
 class ApproveRunRequest(BaseModel):
@@ -82,7 +86,8 @@ async def create_task(task_create: TaskCreate):
             created_at=task.created_at
         )
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -110,7 +115,8 @@ async def list_tasks(limit: int = None):
             for task in tasks
         ]
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -140,7 +146,8 @@ async def get_task(task_id: int):
 
     except HTTPException:
         raise
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -165,7 +172,8 @@ async def delete_task(task_id: int):
         
     except HTTPException:
         raise
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -187,7 +195,8 @@ async def build_prompt(task_description: str = Form(...)):
             "built_prompt": built_prompt
         }
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -258,7 +267,8 @@ async def run_task(task_id: int, test_command: str = "pytest"):
 
         except HTTPException:
             raise
-        except Exception as e:
+        except (ValueError, RuntimeError, SQLAlchemyError) as e:
+            logger.exception("Unhandled error")
             db_manager.update_run_status(run.id, "error", f"Execution error: {str(e)}")
             raise HTTPException(status_code=500, detail=str(e))
 
@@ -275,7 +285,8 @@ async def run_task(task_id: int, test_command: str = "pytest"):
 
     except HTTPException:
         raise
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -364,7 +375,8 @@ async def create_pr(task_id: int, title: str = None, base: str = "main"):
 
     except HTTPException:
         raise
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -425,7 +437,8 @@ async def list_runs(
         
         return result
 
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -495,7 +508,8 @@ async def get_run_detail(run_id: int):
         
     except HTTPException:
         raise
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -536,7 +550,8 @@ async def check_guardrails(content: str = Form(...), content_type: str = Form("c
 
     except HTTPException:
         raise
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -571,7 +586,8 @@ async def get_run_integrity(run_id: int):
 
     except HTTPException:
         raise
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -609,7 +625,8 @@ async def submit_integrity_answers(run_id: int, answers: str = Form(...)):
 
     except HTTPException:
         raise
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -666,7 +683,8 @@ async def get_integrity_metrics():
             ]
         }
         
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -695,7 +713,8 @@ async def get_integrity_rules():
             "last_updated": "2024-01-01T00:00:00Z"
         }
         
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -736,7 +755,8 @@ async def approve_run(run_id: int, request: ApproveRunRequest):
         
     except HTTPException:
         raise
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -773,7 +793,8 @@ async def reject_run(run_id: int, request: RejectRunRequest):
         
     except HTTPException:
         raise
-    except Exception as e:
+    except (ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -153,7 +153,7 @@ class TestGitHubAdapter:
         mock_result = Mock()
         mock_result.returncode = 1
         mock_result.stderr = "Branch already exists"
-        mock_run.side_effect = Exception("Git error")
+        mock_run.side_effect = RuntimeError("Git error")
 
         result = self.adapter.create_branch("test-branch")
 

--- a/tests/test_agent_worker.py
+++ b/tests/test_agent_worker.py
@@ -134,7 +134,7 @@ class TestAgentWorker:
         
         # Mock regen loop to raise exception
         with patch('src.agent.worker.regen_loop') as mock_regen:
-            mock_regen.run_with_regen.side_effect = Exception("Test exception")
+            mock_regen.run_with_regen.side_effect = RuntimeError("Test exception")
             
             await worker._process_task(mock_task)
             

--- a/tests/test_cli_comprehensive.py
+++ b/tests/test_cli_comprehensive.py
@@ -35,7 +35,7 @@ class TestCLIComprehensive:
     @patch('src.cli.get_db_manager')
     def test_cli_init_error(self, mock_db):
         """Test CLI init command error."""
-        mock_db.return_value.create_tables.side_effect = Exception("DB error")
+        mock_db.return_value.create_tables.side_effect = RuntimeError("DB error")
         
         result = self.runner.invoke(app, ["init"])
         
@@ -72,7 +72,7 @@ class TestCLIComprehensive:
     @patch('src.cli.prompt_builder')
     def test_cli_task_error(self, mock_prompt_builder):
         """Test CLI task command error."""
-        mock_prompt_builder.build_task_prompt.side_effect = Exception("Build error")
+        mock_prompt_builder.build_task_prompt.side_effect = ValueError("Build error")
         
         result = self.runner.invoke(app, ["task", "Test task description"])
         
@@ -319,7 +319,7 @@ class TestCLIComprehensive:
     @patch('src.cli.spec_expander')
     def test_cli_expand_error(self, mock_expander):
         """Test CLI expand command error."""
-        mock_expander.expand_task.side_effect = Exception("Expand error")
+        mock_expander.expand_task.side_effect = ValueError("Expand error")
         
         result = self.runner.invoke(app, ["expand", "Test goal"])
         
@@ -387,7 +387,7 @@ class TestCLIComprehensive:
     @patch('src.cli.get_db_manager')
     def test_cli_clarify_not_found(self, mock_db, mock_regen):
         """Test CLI clarify command not found."""
-        mock_regen.clarify_and_continue.side_effect = Exception("Run not found")
+        mock_regen.clarify_and_continue.side_effect = RuntimeError("Run not found")
         
         # Mock database manager
         mock_db.return_value.create_tables.return_value = None
@@ -468,7 +468,7 @@ class TestCLIComprehensive:
     def test_cli_init_project_error(self, mock_scaffold):
         """Test CLI init-project command error."""
         mock_instance = MagicMock()
-        mock_instance.scaffold_project.side_effect = Exception("Project creation failed")
+        mock_instance.scaffold_project.side_effect = RuntimeError("Project creation failed")
         mock_scaffold.return_value = mock_instance
         
         result = self.runner.invoke(app, ["init-project", "demo-repo"])

--- a/tests/test_main_comprehensive.py
+++ b/tests/test_main_comprehensive.py
@@ -72,7 +72,7 @@ class TestMainComprehensive:
     @patch('src.main.get_db_manager')
     def test_create_task_error(self, mock_db_manager):
         """Test create task endpoint error."""
-        mock_db_manager.return_value.create_task.side_effect = Exception("DB error")
+        mock_db_manager.return_value.create_task.side_effect = RuntimeError("DB error")
         
         response = self.client.post("/tasks", json={"task_text": "test task"})
         
@@ -135,7 +135,7 @@ class TestMainComprehensive:
     @patch('src.main.get_db_manager')
     def test_list_tasks_error(self, mock_db_manager):
         """Test list tasks endpoint error."""
-        mock_db_manager.return_value.list_tasks.side_effect = Exception("DB error")
+        mock_db_manager.return_value.list_tasks.side_effect = RuntimeError("DB error")
         
         response = self.client.get("/tasks")
         
@@ -176,7 +176,7 @@ class TestMainComprehensive:
     @patch('src.main.prompt_builder')
     def test_build_prompt_error(self, mock_prompt_builder):
         """Test build prompt endpoint error."""
-        mock_prompt_builder.build_task_prompt.side_effect = Exception("Build error")
+        mock_prompt_builder.build_task_prompt.side_effect = ValueError("Build error")
         
         response = self.client.post("/prompts/build", data={"task_description": "test task"})
         
@@ -316,7 +316,7 @@ class TestMainComprehensive:
     @patch('src.main.get_db_manager')
     def test_list_runs_error(self, mock_db_manager):
         """Test list runs endpoint error."""
-        mock_db_manager.return_value.list_runs.side_effect = Exception("DB error")
+        mock_db_manager.return_value.list_runs.side_effect = RuntimeError("DB error")
         
         response = self.client.get("/runs")
         
@@ -362,7 +362,7 @@ class TestMainComprehensive:
     @patch('src.main.get_db_manager')
     def test_get_run_error(self, mock_db_manager):
         """Test get run endpoint error."""
-        mock_db_manager.return_value.get_run.side_effect = Exception("DB error")
+        mock_db_manager.return_value.get_run.side_effect = RuntimeError("DB error")
         
         response = self.client.get("/runs/1")
         


### PR DESCRIPTION
## Summary
- replace broad `except Exception` with specific `ValueError`, `RuntimeError`, and `SQLAlchemyError` handling
- log failures via `logger.exception` and define module-level loggers
- update tests to reflect refined error handling

## Testing
- `pytest -o addopts=` *(fails: ModuleNotFoundError: No module named 'hypothesis' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b565b40dd8832a8fefb58442ef8bff