### PR TITLE
feat: add run filters

### DIFF
--- a/src/core/db.py
+++ b/src/core/db.py
@@ -149,22 +149,35 @@ class DatabaseManager:
             statement = select(Run).where(Run.id == run_id)
             return session.exec(statement).first()
 
-    def list_runs(self, task_id: int | None = None, limit: int | None = None) -> list[Run]:
-        """List runs, optionally filtered by task ID.
-        
+    def list_runs(
+        self,
+        task_id: int | None = None,
+        limit: int | None = None,
+        status: str | None = None,
+        integrity_min: float | None = None,
+    ) -> list[Run]:
+        """List runs with optional filters.
+
         Args:
             task_id: Filter by task ID (optional)
             limit: Maximum number of runs to return
-            
+            status: Filter by run status (optional)
+            integrity_min: Minimum integrity score (optional)
+
         Returns:
             List of runs
         """
         with self.get_session() as session:
-            if task_id:
-                statement = select(Run).where(Run.task_id == task_id).order_by(Run.created_at.desc())
-            else:
-                statement = select(Run).order_by(Run.created_at.desc())
+            statement = select(Run)
 
+            if task_id:
+                statement = statement.where(Run.task_id == task_id)
+            if status:
+                statement = statement.where(Run.status == status)
+            if integrity_min is not None:
+                statement = statement.where(Run.integrity_score >= integrity_min)
+
+            statement = statement.order_by(Run.created_at.desc())
             if limit:
                 statement = statement.limit(limit)
             return session.exec(statement).all()

--- a/src/main.py
+++ b/src/main.py
@@ -378,14 +378,13 @@ async def list_runs(
     """List runs with optional filters."""
     try:
         db_manager = get_db_manager()
-        runs = db_manager.list_runs(task_id=task_id, limit=limit)
-        
-        # Apply filters
-        if status:
-            runs = [r for r in runs if getattr(r, 'status', None) == status]
-        if integrity_min is not None:
-            runs = [r for r in runs if getattr(r, 'integrity_score', 0) >= integrity_min]
-        
+        runs = db_manager.list_runs(
+            task_id=task_id,
+            status=status,
+            integrity_min=integrity_min,
+            limit=limit,
+        )
+
         result = []
         for run in runs:
             run_data = {


### PR DESCRIPTION
## Summary
- allow DatabaseManager.list_runs to filter by status and minimum integrity score
- forward filter params through API and drop in-memory filtering

## Testing
- `pytest tests -q` *(fails: pytest-cov plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b565b35f68832a85670f17aeed6c82